### PR TITLE
Update CodeTransparencyClient.cs

### DIFF
--- a/sdk/confidentialledger/Azure.Security.CodeTransparency/src/CodeTransparencyClient.cs
+++ b/sdk/confidentialledger/Azure.Security.CodeTransparency/src/CodeTransparencyClient.cs
@@ -262,7 +262,7 @@ namespace Azure.Security.CodeTransparency
         /// Calls <!-- see cref="CcfReceiptVerifier.VerifyTransparentStatementReceipt(JsonWebKey, byte[], byte[])"/> for each receipt found in the transparent statement.-->
         /// </summary>
         /// <param name="transparentStatementCoseSign1Bytes">Receipt cbor or Cose_Sign1 (with an embedded receipt) bytes.</param>
-        public void RunTransparentStatementVerification(byte[] transparentStatementCoseSign1Bytes)
+        public virtual void RunTransparentStatementVerification(byte[] transparentStatementCoseSign1Bytes)
         {
             List<Exception> failures = new List<Exception>();
 


### PR DESCRIPTION
Add `virtual` keyword to RunTransparentStatementVerification to enable consumers to Mock behavior of this client properly for their own functional validation.

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
